### PR TITLE
speedtest-cli does not support the single option

### DIFF
--- a/speedtest.chart.sh
+++ b/speedtest.chart.sh
@@ -27,7 +27,31 @@ speedtest_update() {
 	# for each dimension
 	# remember: KEEP IT SIMPLE AND SHORT
   # Get the up and down speed. Parse them into separate values, and drop the Mbps.
-  speedtest_output=$(speedtest-cli --single --csv)
+speedtest_priority=100
+
+speedtest_check() {
+  require_cmd speedtest-cli || return 1
+  return 0
+}
+
+
+speedtest_create() {
+        # create a chart with 2 dimensions
+        cat <<EOF
+CHART system.connectionspeed '' "System Connection Speed" "Mbps" "connection speed" system.connectionspeed line $((speedtest_priority + 1)) $speedtest_update_every
+DIMENSION down 'Down' absolute 1 1000000
+DIMENSION up 'Up' absolute 1 1000000
+EOF
+
+        return 0
+}
+
+speedtest_update() {
+        # do all the work to collect / calculate the values
+        # for each dimension
+        # remember: KEEP IT SIMPLE AND SHORT
+  # Get the up and down speed. Parse them into separate values, and drop the Mbps.
+  speedtest_output=$(speedtest-cli --csv)
   down=$(echo $speedtest_output | cut -d ',' -f 7 | cut -d '.' -f 1)
   up=$(echo $speedtest_output | cut -d ',' -f 8 | cut -d '.' -f 1)
 


### PR DESCRIPTION
Newer `speedtest-cli` versions do not support the `--single` option.
This is tested in Netdata v1.22.1, and speedtest-cli v2.0.2.