### PR TITLE
Json jq instead of csv/cut

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,13 @@ Just drop the script file into `/usr/libexec/netdata/charts.d/`, and Netdata wil
 
 ## Installation
 
-This plugin requires the [speedtest-cli](https://github.com/sivel/speedtest-cli) python project. Install with `pip install speedtest-cli`.
+* This plugin requires the [speedtest-cli](https://github.com/sivel/speedtest-cli) python project. Install with `pip install speedtest-cli`.
+
+* Also required is the package [jq](https://stedolan.github.io/jq/). Easily installed from EPEL on Centos, or from the default Ubuntu package repositories.
+
+    Centos: `sudo yum install epel-release -y && yum install jq -y`
+
+    Ubuntu: `sudo apt update && apt install jq -y`
 
 ## Configuration
 

--- a/speedtest.chart.sh
+++ b/speedtest.chart.sh
@@ -12,32 +12,32 @@ speedtest_check() {
 
 
 speedtest_create() {
-        # create a chart with 2 dimensions
-        cat <<EOF
+	# create a chart with 2 dimensions
+	cat <<EOF
 CHART system.connectionspeed '' "System Connection Speed" "Mbps" "connection speed" system.connectionspeed line $((speedtest_priority + 1)) $speedtest_update_every
 DIMENSION down 'Down' absolute 1 1000000
 DIMENSION up 'Up' absolute 1 1000000
 EOF
 
-        return 0
+	return 0
 }
 
 speedtest_update() {
-        # do all the work to collect / calculate the values
-        # for each dimension
-        # remember: KEEP IT SIMPLE AND SHORT
+	# do all the work to collect / calculate the values
+	# for each dimension
+	# remember: KEEP IT SIMPLE AND SHORT
   # Get the up and down speed. Parse them into separate values, and drop the Mbps.
   speedtest_output=$(speedtest-cli --single --json)
   down=$(echo $speedtest_output | jq '.download')
   up=$(echo $speedtest_output | jq '.upload')
 
-        # write the result of the work.
-        cat <<VALUESEOF
+	# write the result of the work.
+	cat <<VALUESEOF
 BEGIN system.connectionspeed
 SET down = $down
 SET up = $up
 END
 VALUESEOF
 
-        return 0
+	return 0
 }

--- a/speedtest.chart.sh
+++ b/speedtest.chart.sh
@@ -12,32 +12,32 @@ speedtest_check() {
 
 
 speedtest_create() {
-	# create a chart with 2 dimensions
-	cat <<EOF
+        # create a chart with 2 dimensions
+        cat <<EOF
 CHART system.connectionspeed '' "System Connection Speed" "Mbps" "connection speed" system.connectionspeed line $((speedtest_priority + 1)) $speedtest_update_every
 DIMENSION down 'Down' absolute 1 1000000
 DIMENSION up 'Up' absolute 1 1000000
 EOF
 
-	return 0
+        return 0
 }
 
 speedtest_update() {
-	# do all the work to collect / calculate the values
-	# for each dimension
-	# remember: KEEP IT SIMPLE AND SHORT
+        # do all the work to collect / calculate the values
+        # for each dimension
+        # remember: KEEP IT SIMPLE AND SHORT
   # Get the up and down speed. Parse them into separate values, and drop the Mbps.
-  speedtest_output=$(speedtest-cli --single --csv)
-  down=$(echo $speedtest_output | cut -d ',' -f 7 | cut -d '.' -f 1)
-  up=$(echo $speedtest_output | cut -d ',' -f 8 | cut -d '.' -f 1)
+  speedtest_output=$(speedtest-cli --single --json)
+  down=$(echo $speedtest_output | jq '.download')
+  up=$(echo $speedtest_output | jq '.upload')
 
-	# write the result of the work.
-	cat <<VALUESEOF
+        # write the result of the work.
+        cat <<VALUESEOF
 BEGIN system.connectionspeed
 SET down = $down
 SET up = $up
 END
 VALUESEOF
 
-	return 0
+        return 0
 }


### PR DESCRIPTION
I ran into a bug where one of the fields returned from the CSV output from speedtest-cli contained a comma, therefore it broke the plugin due to `cut` not being a "real" parser for CSV data. Therefore, considering what was available for CSV parsing and JSON for major Linux distros, chose to use the `--json` flag to output the speedtest-cli to be in JSON, and then use `jq` in order to get the download and upload fields. It adds one more per-requisite, but is much more robust.

https://stedolan.github.io/jq/